### PR TITLE
adds empty options hash as arg to to_json override

### DIFF
--- a/lib/uirusu.rb
+++ b/lib/uirusu.rb
@@ -35,7 +35,7 @@ module Uirusu
 end
 
 require 'json'
-require 'rest_client'
+require 'rest-client'
 require 'optparse'
 require 'yaml'
 

--- a/lib/uirusu/vtresult.rb
+++ b/lib/uirusu/vtresult.rb
@@ -123,7 +123,7 @@ module Uirusu
 		# Outputs the result to JSON
 		#
 		# @return [String] JSON representation of the result
-		def to_json
+		def to_json(options={})
 			JSON::pretty_generate(@results.map{|entry| { :vtresult => entry } })
 		end
 


### PR DESCRIPTION
Was seeing this error:

```
ArgumentError: wrong number of arguments (1 for 0)
    /Users/kplummer/Codes/uirusu/lib/uirusu/vtresult.rb:126:in `to_json'
    /Users/kplummer/.rvm/gems/ruby-2.2.3/gems/multi_json-1.11.2/lib/multi_json/adapters/json_common.rb:19:in `to_json'
    /Users/kplummer/.rvm/gems/ruby-2.2.3/gems/multi_json-1.11.2/lib/multi_json/adapters/json_common.rb:19:in `dump'
    /Users/kplummer/.rvm/gems/ruby-2.2.3/gems/multi_json-1.11.2/lib/multi_json/adapter.rb:25:in `dump'
    /Users/kplummer/.rvm/gems/ruby-2.2.3/gems/multi_json-1.11.2/lib/multi_json.rb:136:in `dump'
    /Users/kplummer/.rvm/gems/ruby-2.2.3/gems/sinatra-contrib-1.4.6/lib/sinatra/json.rb:113:in `block in resolve_encoder_action'
    /Users/kplummer/.rvm/gems/ruby-2.2.3/gems/sinatra-contrib-1.4.6/lib/sinatra/json.rb:112:in `each'
    /Users/kplummer/.rvm/gems/ruby-2.2.3/gems/sinatra-contrib-1.4.6/lib/sinatra/json.rb:112:in `resolve_encoder_action'
    /Users/kplummer/.rvm/gems/ruby-2.2.3/gems/sinatra-contrib-1.4.6/lib/sinatra/json.rb:98:in `json'```

When trying to include the result hash in another, then building JSON.  Adding the empty options arg fixes it.  Know issue with overriding to_json I guess: http://stackoverflow.com/a/2574900