### PR TITLE
Add support for the Private API

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -77,6 +77,45 @@ results = Uirusu::VTComment.post_comment(API_KEY, hash, comment)
 print results if results != nil
 ```
 
+### Private API Support
+Private API support is supported by the gem, but is not yet supported in the CLI application. 
+
+Notes:
+* Details on the private API can be found [here](https://www.virustotal.com/en/documentation/private-api)
+* Optional parameters can be sent to the method calls as named parameters (see VTFile#query_report below)
+* #feed and #false_positive are currently not supported, as they require a special API key
+
+#### Examples
+Below are some examples specific to the private API.
+
+##### Files
+```ruby
+# Search for a hash and get additional metadata
+Uirusu::VTFile.query_report(API_KEY, hash, allinfo: 1)
+
+# Get a file upload URL for larger files
+Uirusu::VTFile.scan_upload_url(API_KEY)
+
+# Submit a file with a callback URL
+Uirusu::VTFile.scan_file(API_KEY, filepath, notify_url: 'http://requestb.in/117n0hb1')
+
+# Request a behavioural report on a hash
+Uirusu::VTFile.behaviour(API_KEY, hash)
+
+# Request a network traffic report on a hash
+Uirusu::VTFile.network_traffic(API_KEY, hash)
+```
+
+##### Domains and IPs
+```ruby
+
+# Get a report for a domain
+Uirusu::VTDomain.query_report(API_KEY, domain)
+
+# Get a report for an IP address
+Uirusu::VTIPAddr.query_report(API_KEY, ip)
+```
+
 ##License
 Uirusu is licensed under the MIT license see the `LICENSE` file for the full license.
 

--- a/lib/uirusu/vtcomment.rb
+++ b/lib/uirusu/vtcomment.rb
@@ -23,6 +23,7 @@ module Uirusu
 	# Virustotal.com public API
 	module VTComment
 		POST_URL = Uirusu::VT_API + "/comments/put"
+		GET_URL = Uirusu::VT_API + "/comments/get"
 
 		# Submits a comment to Virustotal.com for a specific resource
 		#
@@ -32,10 +33,6 @@ module Uirusu
 		#
 		# @return [JSON] Parsed response
 		def self.post_comment(api_key, resource, comment)
-			if api_key == nil
-				raise "Invalid API Key"
-			end
-
 			if resource == nil
 				raise "Invalid resource, must be a valid url"
 			end
@@ -44,18 +41,32 @@ module Uirusu
 				raise "You must provide a comment to submit."
 			end
 
-			response = RestClient.post POST_URL, :apikey => api_key, :resource => resource, :comment => comment
+			params = {
+				apikey: api_key,
+				resource: resource,
+				comment: comment
+			}
+			Uirusu.query_api POST_URL, params
+		end
 
-			case response.code
-				when 429, 204
-					raise "Virustotal limit reached. Try again later."
-				when 403
-					raise "Invalid privileges, please check your API key."
-				when 200
-					JSON.parse(response)
-				else
-					raise "Unknown Server error."
+		# Retrieve a list of comments to Virustotal.com for a specific resource
+		#
+		# @param [String] api_key Virustotal.com API key
+		# @param [String] resource MD5/sha1/sha256/scan_id/URL to search for
+		# @param [DateTime] before A datetime token that allows you to iterate over all comments on a specific item whenever it has been commented on more than 25 times
+		#
+		# @return [JSON] Parsed response
+		def self.get_comments(api_key, resource, before=nil)
+			if resource == nil
+				raise "Invalid resource, must be a valid url"
 			end
+
+			params = {
+				apikey: api_key,
+				resource: resource
+			}
+			params[:before] = before unless before.nil?
+			Uirusu.query_api GET_URL, params
 		end
 	end
 end

--- a/lib/uirusu/vtdomain.rb
+++ b/lib/uirusu/vtdomain.rb
@@ -21,54 +21,25 @@
 module Uirusu
 	#
 	#
-	module VTUrl
-		SCAN_URL   = Uirusu::VT_API + "/url/scan"
-		REPORT_URL = Uirusu::VT_API + "/url/report"
+	module VTDomain
+		REPORT_URL = Uirusu::VT_API + "/domain/report"
 
-		# Submits a URL to be scanned by Virustotal.com
+		# Searches reports by Domain from Virustotal.com
 		#
 		# @param api_key Virustotal.com API key
-		# @param resource url to submit
+		# @param domain domain name to search
 		#
 		# @return [JSON] Parsed response
-		def self.scan_url(api_key, resource)
-			if resource == nil
-				raise "Invalid resource, must be a valid url"
+		def self.query_report(api_key, domain)
+			if domain == nil
+				raise "Invalid resource, must be a valid domain"
 			end
 
 			params = {
 				apikey: api_key,
-				resource: resource
+				domain: domain
 			}
-			Uirusu.query_api SCAN_URL, params
-		end
-
-		# Searches reports by URL from Virustotal.com
-		#
-		# @param api_key Virustotal.com API key
-		# @param resource url to search
-		#
-		# @return [JSON] Parsed response
-		def self.query_report(api_key, resource, **args)
-			if resource == nil
-				raise "Invalid resource, must be a valid url"
-			end
-
-			params = {
-				apikey: api_key,
-				resource: resource
-			}
-			Uirusu.query_api REPORT_URL, params.merge!(args)
-		end
-
-		# Searches reports by URL from Virustotal.com
-		#
-		# @param api_key Virustotal.com API key
-		# @param resource url to search
-		#
-		# @return [JSON] Parsed response
-		def self.feed(api_key, resource, **args)
-			raise "#feed not yet implemented. This API call is only available to users that have licensed the unlimited tier of VirusTotal private Mass API."
+			Uirusu.query_api REPORT_URL, params
 		end
 	end
 end

--- a/lib/uirusu/vtfile.rb
+++ b/lib/uirusu/vtfile.rb
@@ -53,7 +53,7 @@ module Uirusu
 				apikey: api_key,
 				resource: resource
 			}
-			self.query_api REPORT_URL, params.merge!(args)
+			Uirusu.query_api REPORT_URL, params.merge!(args)
 		end
 
         # Submits a file to Virustotal.com for analysis
@@ -73,7 +73,7 @@ module Uirusu
                 filename: path_to_file, 
                 file: File.new(path_to_file, 'rb')
             }
-            self.query_api SCAN_URL, params.merge!(args), true
+            Uirusu.query_api SCAN_URL, params.merge!(args), true
         end
 
 		# Retrieves a custom upload URL for files larger than 32MB
@@ -85,7 +85,7 @@ module Uirusu
 			params = { 
 				apikey: api_key
 			}
-			self.query_api SCAN_UPLOAD_URL, params
+			Uirusu.query_api SCAN_UPLOAD_URL, params
 		end
 
         # Requests an existing file to be rescanned.
@@ -105,7 +105,7 @@ module Uirusu
                 resource: resource
             }
 
-            self.query_api RESCAN_URL, params.merge!(args), true
+            Uirusu.query_api RESCAN_URL, params.merge!(args), true
         end
 
 		# Deletes a scheduled rescan request.
@@ -124,7 +124,7 @@ module Uirusu
 				resource: resource
 			}
 
-			self.query_api RESCAN_DELETE_URL, params, true
+			Uirusu.query_api RESCAN_DELETE_URL, params, true
 		end
 
 		# Requests a behavioural report on a hash.
@@ -142,7 +142,7 @@ module Uirusu
 				apikey: api_key,
 				hash: hash
 			}
-			self.query_api BEHAVIOUR_URL, params
+			Uirusu.query_api BEHAVIOUR_URL, params
 		end
 
 		# Requests a network traffic report on a hash.
@@ -160,7 +160,7 @@ module Uirusu
 				apikey: api_key,
 				hash: hash
 			}
-			self.query_api NETWORK_TRAFFIC_URL, params
+			Uirusu.query_api NETWORK_TRAFFIC_URL, params
 		end
 
 		# Perform an advanced reverse search.
@@ -179,7 +179,7 @@ module Uirusu
 				apikey: api_key,
 				query: query
 			}
-			self.query_api SEARCH_URL, params.merge!(args)
+			Uirusu.query_api SEARCH_URL, params.merge!(args)
 		end
 
 		# Access the clustering section of VT Intelligence.
@@ -197,7 +197,7 @@ module Uirusu
 				apikey: api_key,
 				date: date
 			}
-			self.query_api CLUSTERS_URL, params
+			Uirusu.query_api CLUSTERS_URL, params
 		end
 
 		# Download a file from vT's store given a hash.
@@ -215,7 +215,7 @@ module Uirusu
 				apikey: api_key,
 				hash: hash
 			}
-			self.query_api DOWNLOAD_URL, params
+			Uirusu.query_api DOWNLOAD_URL, params
 		end
 
 		# Retrieve a live feed of all uploaded files to VT.
@@ -236,51 +236,6 @@ module Uirusu
 		# @return [JSON] Parsed response
 		def self.false_positives(api_key, limit=100)
 			raise "#false_positives not yet implemented. This API is only available to antivirus vendors participating in VirusTotal."
-		end
-
-
-		private
-		def self.query_api(url, params, post=false)
-			if params[:apikey] == nil
-				raise "Invalid API Key"
-			end
-
-			begin
-				if post
-					response = RestClient.post url, **params
-				else
-					response = RestClient.get url, params: params
-				end
-			rescue => e
-				response = e.response
-			end
-			self.parse_response response
-		end
-
-		# Parses the response or raises an exception accordingly.
-		#
-		# @param response The response from RestClient
-		#
-		# @return [JSON] Parsed response
-		def self.parse_response(response)
-			case response.code
-				when 429, 204
-					raise "Virustotal limit reached. Try again later."
-				when 403
-					raise "Invalid privileges, please check your API key."
-				when 200
-					# attempt to parse it as json, otherwise return the raw response
-					# network_traffic and download return non-JSON data
-					begin
-						JSON.parse(response)
-					rescue
-						response
-					end
-				when 500
-					nil
-				else
-					raise "Unknown Server error. (#{response.code})"
-			end
-		end
+		end	
 	end
 end

--- a/lib/uirusu/vtfile.rb
+++ b/lib/uirusu/vtfile.rb
@@ -23,98 +23,263 @@ module Uirusu
 	# Module for Accessing the File scan and report functionalities of the
 	# Virustotal.com public API
 	module VTFile
-		SCAN_URL   = Uirusu::VT_API + "/file/scan"
-		RESCAN_URL = Uirusu::VT_API + "/file/rescan"
-		REPORT_URL = Uirusu::VT_API + "/file/report"
+        SCAN_URL             = Uirusu::VT_API + "/file/scan"
+		SCAN_UPLOAD_URL      = Uirusu::VT_API + "/file/scan/upload_url"
+        RESCAN_URL           = Uirusu::VT_API + "/file/rescan"
+		RESCAN_DELETE_URL    = Uirusu::VT_API + "/file/rescan/delete"
+		REPORT_URL           = Uirusu::VT_API + "/file/report"
+		BEHAVIOUR_URL        = Uirusu::VT_API + "/file/behaviour"
+		NETWORK_TRAFFIC_URL	 = Uirusu::VT_API + "/file/network-traffic"
+		SEARCH_URL           = Uirusu::VT_API + "/file/search"
+		CLUSTERS_URL         = Uirusu::VT_API + "/file/clusters"
+		DOWNLOAD_URL         = Uirusu::VT_API + "/file/download"
+		FEED_URL             = Uirusu::VT_API + "/file/feed" #not implemented
+		FALSE_POSITIVES_URL  = Uirusu::VT_API + "/file/false-positives" #not implemented
+
 
 		# Queries a report from Virustotal.com
 		#
 		# @param api_key Virustotal.com API key
 		# @param resource MD5/sha1/sha256/scan_id to search for
+		# @params **args named arguments for optional parameters - https://www.virustotal.com/en/documentation/private-api/#get-report
 		#
 		# @return [JSON] Parsed response
-		def VTFile.query_report(api_key, resource)
-			if api_key == nil
-				raise "Invalid API Key"
-			end
-
+		def VTFile.query_report(api_key, resource, **args)
 			if resource == nil
 				raise "Invalid resource, must be md5/sha1/sha256/scan_id"
 			end
 
-			response = RestClient.post REPORT_URL, :apikey => api_key, :resource => resource
-
-			case response.code
-				when 429, 204
-					raise "Virustotal limit reached. Try again later."
-				when 403
-					raise "Invalid privileges, please check your API key."
-				when 200
-					JSON.parse(response)
-				when 500
-					nil
-				else
-					raise "Unknown Server error."
-			end
+			params = {
+				apikey: api_key,
+				resource: resource
+			}
+			self.query_api REPORT_URL, params.merge!(args)
 		end
 
-		# Submits a file to Virustotal.com for analysis
+        # Submits a file to Virustotal.com for analysis
+        #
+        # @param api_key Virustotal.com API key
+        # @param path_to_file Path to file on disk to upload
+        # @params **args named arguments for optional parameters - https://www.virustotal.com/en/documentation/private-api/#scan
+        #
+        # @return [JSON] Parsed response
+        def self.scan_file(api_key, path_to_file, **args)
+            if !File.exists?(path_to_file)
+                raise Errno::ENOENT
+            end
+
+            params = { 
+                apikey: api_key,
+                filename: path_to_file, 
+                file: File.new(path_to_file, 'rb')
+            }
+            self.query_api SCAN_URL, params.merge!(args), true
+        end
+
+		# Retrieves a custom upload URL for files larger than 32MB
 		#
 		# @param api_key Virustotal.com API key
-		# @param path_to_file Path to file on disk to upload
 		#
 		# @return [JSON] Parsed response
-		def self.scan_file(api_key, path_to_file)
-			if !File.exists?(path_to_file)
-				raise Errno::ENOENT
-			end
-
-			if api_key == nil
-				raise "Invalid API Key"
-			end
-
-			response = RestClient.post SCAN_URL, :apikey => api_key, :filename=> path_to_file, :file => File.new(path_to_file, 'rb')
-
-			case response.code
-				when 429, 204
-					raise "Virustotal limit reached. Try again later."
-				when 403
-					raise "Invalid privileges, please check your API key."
-				when 200
-					JSON.parse(response)
-				else
-					raise "Unknown Server error."
-			end
+		def self.scan_upload_url(api_key)
+			params = { 
+				apikey: api_key
+			}
+			self.query_api SCAN_UPLOAD_URL, params
 		end
 
-		# Requests an existing file to be rescanned.
+        # Requests an existing file to be rescanned.
+        #
+        # @param api_key Virustotal.com API key
+        # @param resource MD5/sha1/sha256/scan_id to rescan
+        # @params **args named arguments for optional parameters - https://www.virustotal.com/en/documentation/private-api/#rescan
+        #
+        # @return [JSON] Parsed response
+        def self.rescan_file(api_key, resource, **args)
+            if resource == nil
+                raise "Invalid resource, must be md5/sha1/sha256/scan_id"
+            end
+
+            params = { 
+                apikey: api_key,
+                resource: resource
+            }
+
+            self.query_api RESCAN_URL, params.merge!(args), true
+        end
+
+		# Deletes a scheduled rescan request.
 		#
 		# @param api_key Virustotal.com API key
 		# @param resource MD5/sha1/sha256/scan_id to rescan
 		#
 		# @return [JSON] Parsed response
-		def self.rescan_file(api_key, resource)
-			if api_key == nil
-				raise "Invalid API Key"
-			end
-
+		def self.rescan_delete(api_key, resource)
 			if resource == nil
 				raise "Invalid resource, must be md5/sha1/sha256/scan_id"
 			end
 
-			response = RestClient.post RESCAN_URL, :apikey => api_key, :resource => resource
+			params = { 
+				apikey: api_key,
+				resource: resource
+			}
 
+			self.query_api RESCAN_DELETE_URL, params, true
+		end
+
+		# Requests a behavioural report on a hash.
+		#
+		# @param api_key Virustotal.com API key
+		# @param hash MD5/sha1/sha256 to query
+		#
+		# @return [JSON] Parsed response
+		def self.behaviour(api_key, hash)
+			if hash == nil
+				raise "Invalid hash, must be md5/sha1/sha256"
+			end
+
+			params = {
+				apikey: api_key,
+				hash: hash
+			}
+			self.query_api BEHAVIOUR_URL, params
+		end
+
+		# Requests a network traffic report on a hash.
+		#
+		# @param api_key Virustotal.com API key
+		# @param hash MD5/sha1/sha256 to query
+		#
+		# @return [PCAP] A PCAP file containing the network traffic dump
+		def self.network_traffic(api_key, hash)
+			if hash == nil
+				raise "Invalid hash, must be md5/sha1/sha256"
+			end
+
+			params = {
+				apikey: api_key,
+				hash: hash
+			}
+			self.query_api NETWORK_TRAFFIC_URL, params
+		end
+
+		# Perform an advanced reverse search.
+		#
+		# @param api_key Virustotal.com API key
+		# @param query A search modifier compliant file search query (https://www.virustotal.com/intelligence/help/file-search/#search-modifiers)
+		# @param **args named optional arguments - https://www.virustotal.com/en/documentation/private-api/#search
+		#
+		# @return [JSON] Parsed response
+		def self.search(api_key, query, **args)
+			if query == nil
+				raise "Please enter a valid query."
+			end
+
+			params = {
+				apikey: api_key,
+				query: query
+			}
+			self.query_api SEARCH_URL, params.merge!(args)
+		end
+
+		# Access the clustering section of VT Intelligence.
+		#
+		# @param api_key Virustotal.com API key
+		# @param date A specific day for which we want to access the clustering details, example: 2013-09-10
+		#
+		# @return [JSON] Parsed response
+		def self.clusters(api_key, date)
+			if date == nil
+				raise "Please enter a valid date (Ex: 2013-09-10)"
+			end
+
+			params = {
+				apikey: api_key,
+				date: date
+			}
+			self.query_api CLUSTERS_URL, params
+		end
+
+		# Download a file from vT's store given a hash.
+		#
+		# @param api_key Virustotal.com API key
+		# @param hash The md5/sha1/sha256 of the file you want to download
+		#
+		# @return [File] the downloaded file
+		def self.download(api_key, hash)
+			if hash == nil
+				raise "Please enter a valid md5/sha1/sha256 hash"
+			end
+
+			params = {
+				apikey: api_key,
+				hash: hash
+			}
+			self.query_api DOWNLOAD_URL, params
+		end
+
+		# Retrieve a live feed of all uploaded files to VT.
+		#
+		# @param api_key Virustotal.com API key
+		# @param package Indicates a time window to pull reports on all items received during such window. Only per-minute and hourly windows are allowed, the format is %Y%m%dT%H%M (e.g. 20160304T0900) or %Y%m%dT%H (e.g. 20160304T09). Time is expressed in UTC.
+		#
+		# @return [JSON] Parsed response
+		def self.feed(api_key, package)
+			raise "#false_positives not yet implemented. This API call is only available to users that have licensed the unlimited tier of VirusTotal private Mass API."
+		end
+
+		# Allows vendors to consume false positive notifications for files that they mistakenly detect.
+		#
+		# @param api_key Virustotal.com API key
+		# @param limit The number of false positive notifications to consume, if available. The max value is 1000.
+		#
+		# @return [JSON] Parsed response
+		def self.false_positives(api_key, limit=100)
+			raise "#false_positives not yet implemented. This API is only available to antivirus vendors participating in VirusTotal."
+		end
+
+
+		private
+		def self.query_api(url, params, post=false)
+			if params[:apikey] == nil
+				raise "Invalid API Key"
+			end
+
+			begin
+				if post
+					response = RestClient.post url, **params
+				else
+					response = RestClient.get url, params: params
+				end
+			rescue => e
+				response = e.response
+			end
+			self.parse_response response
+		end
+
+		# Parses the response or raises an exception accordingly.
+		#
+		# @param response The response from RestClient
+		#
+		# @return [JSON] Parsed response
+		def self.parse_response(response)
 			case response.code
 				when 429, 204
 					raise "Virustotal limit reached. Try again later."
 				when 403
 					raise "Invalid privileges, please check your API key."
 				when 200
-					JSON.parse(response)
+					# attempt to parse it as json, otherwise return the raw response
+					# network_traffic and download return non-JSON data
+					begin
+						JSON.parse(response)
+					rescue
+						response
+					end
 				when 500
 					nil
 				else
-					raise "Unknown Server error."
+					raise "Unknown Server error. (#{response.code})"
 			end
 		end
 	end

--- a/lib/uirusu/vtipaddr.rb
+++ b/lib/uirusu/vtipaddr.rb
@@ -21,54 +21,25 @@
 module Uirusu
 	#
 	#
-	module VTUrl
-		SCAN_URL   = Uirusu::VT_API + "/url/scan"
-		REPORT_URL = Uirusu::VT_API + "/url/report"
+	module VTIPAddr
+		REPORT_URL = Uirusu::VT_API + "/ip-address/report"
 
-		# Submits a URL to be scanned by Virustotal.com
+		# Searches reports by IP from Virustotal.com
 		#
 		# @param api_key Virustotal.com API key
-		# @param resource url to submit
+		# @param ip IP address to search
 		#
 		# @return [JSON] Parsed response
-		def self.scan_url(api_key, resource)
-			if resource == nil
-				raise "Invalid resource, must be a valid url"
+		def self.query_report(api_key, ip)
+			if ip == nil
+				raise "Invalid resource, must be a valid IPv4 address"
 			end
 
 			params = {
 				apikey: api_key,
-				resource: resource
+				ip: ip
 			}
-			Uirusu.query_api SCAN_URL, params
-		end
-
-		# Searches reports by URL from Virustotal.com
-		#
-		# @param api_key Virustotal.com API key
-		# @param resource url to search
-		#
-		# @return [JSON] Parsed response
-		def self.query_report(api_key, resource, **args)
-			if resource == nil
-				raise "Invalid resource, must be a valid url"
-			end
-
-			params = {
-				apikey: api_key,
-				resource: resource
-			}
-			Uirusu.query_api REPORT_URL, params.merge!(args)
-		end
-
-		# Searches reports by URL from Virustotal.com
-		#
-		# @param api_key Virustotal.com API key
-		# @param resource url to search
-		#
-		# @return [JSON] Parsed response
-		def self.feed(api_key, resource, **args)
-			raise "#feed not yet implemented. This API call is only available to users that have licensed the unlimited tier of VirusTotal private Mass API."
+			Uirusu.query_api REPORT_URL, params
 		end
 	end
 end

--- a/test/functional/vtfile_test.rb
+++ b/test/functional/vtfile_test.rb
@@ -51,6 +51,19 @@ class VTFileTest < Minitest::Test
 		results = Uirusu::VTFile.query_report(@app_test.config['virustotal']['api-key'], hash)
 		result = Uirusu::VTResult.new(hash, results)
 
-		assert_equal 54, result.results.size
+		assert_equal 55, result.results.size
+	end
+
+	def test_return_additional_info_for_hash_FD287794107630FA3116800E617466A9
+		# Skip the test if we dont have a API key
+		if @app_test.config.empty? || @app_test.config['virustotal']['api-key'] == nil || !@app_test.config['virustotal']['private']
+			skip
+		end
+
+		hash = "FD287794107630FA3116800E617466A9" #Hash for a version of Poison Ivy
+
+		results = Uirusu::VTFile.query_report(@app_test.config['virustotal']['api-key'], hash, allinfo: 1)
+
+		assert_includes results.keys, "additional_info"
 	end
 end

--- a/test/functional/vturl_test.rb
+++ b/test/functional/vturl_test.rb
@@ -51,6 +51,19 @@ class VTUrlTest < Minitest::Test
 		results = Uirusu::VTUrl.query_report(@app_test.config['virustotal']['api-key'], url)
 		result = Uirusu::VTResult.new(url, results)
 
-		assert_equal 67, result.results.size
+		assert_equal 68, result.results.size
+	end
+
+	def test_return_additional_info_for_url_google_com
+		# Skip the test if we dont have a API key
+		if @app_test.config.empty? || @app_test.config['virustotal']['api-key'] == nil || !@app_test.config['virustotal']['private']
+			skip
+		end
+
+		url = "http://www.google.com"
+
+		results = Uirusu::VTUrl.query_report(@app_test.config['virustotal']['api-key'], url, allinfo: 1)
+
+		assert_includes results.keys, "additional_info"
 	end
 end


### PR DESCRIPTION
Addresses issue #11 by adding functionality to call the API endpoints for the [VirusTotal Private API](https://www.virustotal.com/en/documentation/private-api). 

* Adds additional methods for previously unsupported endpoints
* Modifies existing methods to support optional parameters that are used in the Private API
* Refactored some of the code to extract repeated functionality into the base class to allow for less repetition and better reusability